### PR TITLE
Fix IllegalFormatConversionException

### DIFF
--- a/d2j-smali/src/main/java/com/googlecode/d2j/smali/BaksmaliCodeDumper.java
+++ b/d2j-smali/src/main/java/com/googlecode/d2j/smali/BaksmaliCodeDumper.java
@@ -245,7 +245,7 @@ import java.util.*;
     public void visitFilledNewArrayStmt(Op op, int[] args, String type) {
         if (args.length > 0) {
             if (op.format == InstructionFormat.kFmt3rc) { // invoke-x/range
-                out.s("%s { %d .. %d }, %s", op.displayName, reg(args[0]), reg(args[args.length - 1]),
+                out.s("%s { %s .. %s }, %s", op.displayName, reg(args[0]), reg(args[args.length - 1]),
                         BaksmaliDumper.escapeType(type));
             } else {
                 StringBuilder buff = new StringBuilder();


### PR DESCRIPTION
This PR fixes a `java.util.IllegalFormatConversionException`, which would occur when decompiling certain APKs:

```
com.googlecode.d2j.DexException: Error process class: [731]Landroid/support/e/a;
  at com.googlecode.d2j.reader.DexFileReader.accept(DexFileReader.java:604)
  at com.googlecode.d2j.reader.DexFileReader.accept(DexFileReader.java:565)
  at com.googlecode.d2j.smali.Baksmali.to(Baksmali.java:99)
  at com.googlecode.d2j.smali.BaksmaliCmd.doCommandLine(BaksmaliCmd.java:60)
  at com.googlecode.dex2jar.tools.BaseCmd.doMain(BaseCmd.java:288)
  at com.googlecode.d2j.smali.BaksmaliCmd.main(BaksmaliCmd.java:24)
Caused by: java.util.IllegalFormatConversionException: d != java.lang.String
  at java.base/java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4421)
  at java.base/java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2936)
  at java.base/java.util.Formatter$FormatSpecifier.print(Formatter.java:2890)
  at java.base/java.util.Formatter.format(Formatter.java:2671)
  at java.base/java.util.Formatter.format(Formatter.java:2607)
  at java.base/java.lang.String.format(String.java:2734)
  at com.googlecode.d2j.smali.BaksmaliDumpOut.s(BaksmaliDumpOut.java:62)
  at com.googlecode.d2j.smali.BaksmaliCodeDumper.visitFilledNewArrayStmt(BaksmaliCodeDumper.java:252)
  at com.googlecode.d2j.node.DexCodeNode$FilledNewArrayStmtNode.accept(DexCodeNode.java:300)
  at com.googlecode.d2j.node.DexCodeNode.accept(DexCodeNode.java:62)
  at com.googlecode.d2j.smali.BaksmaliDumper.baksmaliCode(BaksmaliDumper.java:517)
  at com.googlecode.d2j.smali.BaksmaliDumper.baksmaliMethod(BaksmaliDumper.java:445)
  at com.googlecode.d2j.smali.BaksmaliDumper.baksmaliClass(BaksmaliDumper.java:397)
  at com.googlecode.d2j.smali.BaksmaliDexFileVisitor$1.visitEnd(BaksmaliDexFileVisitor.java:60)
  at com.googlecode.d2j.reader.DexFileReader.accept(DexFileReader.java:601)
  ... 5 more
```