### PR TITLE
Preserve names of parameters and locals in dex2jar

### DIFF
--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -1,19 +1,60 @@
 package com.googlecode.d2j.dex;
 
-import java.util.*;
-
+import com.googlecode.d2j.DexConstants;
+import com.googlecode.d2j.DexLabel;
+import com.googlecode.d2j.DexType;
+import com.googlecode.d2j.Field;
+import com.googlecode.d2j.Method;
+import com.googlecode.d2j.MethodHandle;
+import com.googlecode.d2j.Proto;
+import com.googlecode.d2j.Visibility;
 import com.googlecode.d2j.converter.Dex2IRConverter;
-import org.objectweb.asm.*;
-import org.objectweb.asm.tree.InnerClassNode;
-
-import com.googlecode.d2j.*;
 import com.googlecode.d2j.converter.IR2JConverter;
-import com.googlecode.d2j.node.*;
+import com.googlecode.d2j.node.DexAnnotationNode;
+import com.googlecode.d2j.node.DexClassNode;
+import com.googlecode.d2j.node.DexDebugNode;
+import com.googlecode.d2j.node.DexFieldNode;
+import com.googlecode.d2j.node.DexFileNode;
+import com.googlecode.d2j.node.DexMethodNode;
 import com.googlecode.dex2jar.ir.IrMethod;
-import com.googlecode.dex2jar.ir.ts.*;
+import com.googlecode.dex2jar.ir.ts.AggTransformer;
+import com.googlecode.dex2jar.ir.ts.CleanLabel;
+import com.googlecode.dex2jar.ir.ts.DeadCodeTransformer;
+import com.googlecode.dex2jar.ir.ts.EndRemover;
+import com.googlecode.dex2jar.ir.ts.ExceptionHandlerTrim;
+import com.googlecode.dex2jar.ir.ts.Ir2JRegAssignTransformer;
+import com.googlecode.dex2jar.ir.ts.MultiArrayTransformer;
+import com.googlecode.dex2jar.ir.ts.NewTransformer;
+import com.googlecode.dex2jar.ir.ts.NpeTransformer;
+import com.googlecode.dex2jar.ir.ts.RemoveConstantFromSSA;
+import com.googlecode.dex2jar.ir.ts.RemoveLocalFromSSA;
+import com.googlecode.dex2jar.ir.ts.TypeTransformer;
+import com.googlecode.dex2jar.ir.ts.UnSSATransformer;
+import com.googlecode.dex2jar.ir.ts.VoidInvokeTransformer;
+import com.googlecode.dex2jar.ir.ts.ZeroTransformer;
 import com.googlecode.dex2jar.ir.ts.array.FillArrayTransformer;
 
-import sun.reflect.generics.tree.Tree;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.InnerClassNode;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
 
 public class Dex2Asm {
 
@@ -597,30 +638,39 @@ public class Dex2Asm {
             boolean isStatic = (methodNode.access & Opcodes.ACC_STATIC) != 0;
             String[] paramTypes = methodNode.method.getParameterTypes();
 
+            int localsOffset = 0;
             Map<Integer, LocalVar> localVars = new TreeMap<>();
             if (!isStatic) {
-                LocalVar local = new LocalVar(0, "this", methodNode.method.getOwner(), null);
+                LocalVar local = new LocalVar(localsOffset, "this", methodNode.method.getOwner(), null);
                 localVars.put(local.reg, local);
+                localsOffset++;
             }
 
             // Handle debugNode.parameterNames
             if (debugNode.parameterNames != null) {
-                for (int i = 0; i < debugNode.parameterNames.size(); i++) {
-                    String paramName = debugNode.parameterNames.get(i);
+                for (int i = 0; i < paramTypes.length; i++) {
+                    String paramName = i < debugNode.parameterNames.size() ? debugNode.parameterNames.get(i) : null;
+                    String paramType = paramTypes[i];
 
                     // Put parameter name in MethodParameters attribute
                     mv.visitParameter(paramName, 0);
 
                     // Also put it into the LocalVariableTable
                     if (paramName != null) {
-                        LocalVar local = new LocalVar(isStatic ? i : i + 1, paramName, paramTypes[i], null);
+                        LocalVar local = new LocalVar(localsOffset, paramName, paramType, null);
                         localVars.put(local.reg, local);
+                    }
+
+                    // If the local variable at index is of type double or long, it occupies both index and index + 1.
+                    if ("J".equals(paramType) || "D".equals(paramType)) {
+                        localsOffset += 2;
+                    } else {
+                        localsOffset++;
                     }
                 }
             }
 
             // Handle debugNodes to create a LocalVariableTable
-            int localsOffset = paramTypes.length + (isStatic ? 0 : 1);
             if (debugNode.debugNodes != null) {
                 for (DexDebugNode.DexDebugOpNode opDebugNode : debugNode.debugNodes) {
                     if (opDebugNode instanceof DexDebugNode.DexDebugOpNode.StartLocalNode) {

--- a/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
+++ b/dex-translator/src/main/java/com/googlecode/d2j/dex/Dex2Asm.java
@@ -671,6 +671,7 @@ public class Dex2Asm {
             }
 
             // Handle debugNodes to create a LocalVariableTable
+            /*
             if (debugNode.debugNodes != null) {
                 for (DexDebugNode.DexDebugOpNode opDebugNode : debugNode.debugNodes) {
                     if (opDebugNode instanceof DexDebugNode.DexDebugOpNode.StartLocalNode) {
@@ -683,10 +684,11 @@ public class Dex2Asm {
                         LocalVar localVar = localVars.get(localsOffset + endLocalNode.reg);
                         if (localVar != null) {
                             localVar.end = endLocalNode.label;
+                            localVars.remove(endLocalNode.reg);
                         }
                     }
                 }
-            }
+            }*/
 
             for (LocalVar localVar : localVars.values()) {
                 Label startLabel = new Label(); //FIXME: map from localVar.start


### PR DESCRIPTION
I'm using dex2jar + CFR to extract Java sources from Android 11's framework.jar (AFAICT they didn't release the Java sources for the betas yet -- Please prove me wrong)

Unfortunately, the source code doesn't preserve variable names and, most importantly, method parameter names.

But when examining the output of dex2smali, I noticed parameter names were there, show with the `.param p#, "name"` syntax.

This PR copies parameter and local variable names from debug section in into java bytecode, using both `MethodVisitor.visitParameter` (Which AFAICT translates into Java 8's MethodParameters attribute) and `MethodVisitor.visitLocalVariable` (Which translates into LocalVariableTable attribute).

Those are intended for debugging, but are also used by decompilers to assign names


However there are a few issues:
- Argument names are unknown in interfaces -- Probably cannot be fixed if the information isn't there?
- I don't know how to translate DexLabel into a Asm Label, therefore the entries in my LocalVariableTable have start=stop=0
- Decompilers successfully decode parameter names, but local variable names are mixed up -- E.g., https://gist.github.com/paulo-raca/2551cc5da2ecc86877c6f0ccb6153970. Please help me mapping it properly
- Code can probably be improved, please make suggestions :)
