### PR TITLE
fix typos of hex strings decoding

### DIFF
--- a/dex-translator/src/test/java/res/Hex.java
+++ b/dex-translator/src/test/java/res/Hex.java
@@ -50,15 +50,15 @@ public class Hex {
             }
             int ll = 0;
             if (l >= '0' && l <= '9') {
-                ll = h - '0';
+                ll = l - '0';
             } else if (l >= 'a' && l <= 'f') {
-                ll = h - 'a' + 10;
+                ll = l - 'a' + 10;
             } else if (l >= 'A' && l <= 'F') {
-                ll = h - 'A' + 10;
+                ll = l - 'A' + 10;
             } else {
                 throw new RuntimeException();
             }
-            d[i] = (char) ((hh << 4) | ll);
+            ret[i] = (byte) ((hh << 4) | ll);
         }
         return ret;
     }


### PR DESCRIPTION
Hex strings encoding and decoding has been described in #513.
There are some typos in res/Hex.java.

Also, I found some bugs for hex strings encoding and decoding. When I use dex2jar to translate [Webmon](https://f-droid.org/en/packages/ooo.akito.webmon/) App, an int array `AppCompatTheme` in `androidx.appcompat.R.class` is encoded as a hex string. But the decode function `res.Hex#decode_B` is not included in the translated jar. I added `res/Hex.class` to java classloader's class path and it can work.