### PR TITLE
Add gradle 7 support by fixing deprecated notations in  build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects  {
-  apply plugin: 'maven'
+  apply plugin: 'maven-publish'
   apply plugin: 'idea'
   apply plugin: 'eclipse'
   group = 'com.googlecode.d2j'
@@ -9,8 +9,8 @@ allprojects  {
 defaultTasks('clean','distZip')
 
 subprojects {
-  apply plugin: 'java'
-  apply plugin: 'maven'
+  apply plugin: 'java-library'
+  apply plugin: 'maven-publish'
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
@@ -38,8 +38,8 @@ subprojects {
   [compileJava, compileTestJava]*.options.collect {options ->options.encoding = 'UTF-8'}
 
   dependencies {
-    testCompile group: 'junit', name: 'junit', version:'4.11'
-    compile fileTree(dir: 'libs', include: '*.jar')
+    testImplementation group: 'junit', name: 'junit', version:'4.11'
+    api fileTree(dir: 'libs', include: '*.jar')
   }
 
   jar {

--- a/d2j-jasmin/build.gradle
+++ b/d2j-jasmin/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'antlr'
 
 dependencies {
-  compile(group: 'org.antlr', name: 'antlr-runtime', version:'3.5.2') {
+  api(group: 'org.antlr', name: 'antlr-runtime', version:'3.5.2') {
         exclude(module: 'stringtemplate')
   }
-  compile "org.ow2.asm:asm-debug-all:5.0.3"
-  compile project(':d2j-base-cmd')
+  api "org.ow2.asm:asm-debug-all:5.0.3"
+  api project(':d2j-base-cmd')
+  api "org.antlr:antlr:3.5.2"
   antlr "org.antlr:antlr:3.5.2"
 }
 

--- a/d2j-smali/build.gradle
+++ b/d2j-smali/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'antlr'
 
 dependencies {
-  compile 'org.antlr:antlr4-runtime:4.5'
-  compile project(':dex-reader')
+  api 'org.antlr:antlr4-runtime:4.5'
+  api project(':dex-reader')
   antlr 'org.antlr:antlr4:4.5'
-  compile project(':d2j-base-cmd')
-  compile project(':dex-writer')
-  testCompile 'org.smali:baksmali:2.0.6'
+  api project(':d2j-base-cmd')
+  api project(':dex-writer')
+  testImplementation 'org.smali:baksmali:2.0.6'
 }
 
 generateGrammarSource {

--- a/dex-ir/build.gradle
+++ b/dex-ir/build.gradle
@@ -1,6 +1,6 @@
 description = 'Dex Translator'
 
 dependencies {
-  compile project(':dex-reader-api')
+  api project(':dex-reader-api')
 }
 

--- a/dex-reader/build.gradle
+++ b/dex-reader/build.gradle
@@ -1,8 +1,8 @@
 description = 'Dex Reader'
 
 dependencies {
-    compile project(':dex-reader-api')
-    testCompile (group: 'org.apache.commons', name: 'commons-compress', version:'1.4.1')
+    api project(':dex-reader-api')
+    testImplementation (group: 'org.apache.commons', name: 'commons-compress', version:'1.4.1')
 }
 
 

--- a/dex-tools/build.gradle
+++ b/dex-tools/build.gradle
@@ -4,11 +4,11 @@ apply plugin:'application'
 mainClassName="com.googlecode.dex2jar.tools.BaseCmd"
 
 dependencies {
-  compile project(':dex-translator')
-  compile project(':d2j-smali')
-  compile project(':d2j-jasmin')
-  compile project(':dex-writer')
-  compile project(':d2j-base-cmd')
+  api project(':dex-translator')
+  api project(':d2j-smali')
+  api project(':d2j-jasmin')
+  api project(':dex-writer')
+  api project(':d2j-base-cmd')
 }
 
 task bin_gen(type: JavaExec) {
@@ -16,7 +16,7 @@ task bin_gen(type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     ext.binDir="$buildDir/generated-sources/bin"
     outputs.dir file(ext.binDir)
-    main='com.googlecode.dex2jar.bin_gen.BinGen'
+    mainClass='com.googlecode.dex2jar.bin_gen.BinGen'
     args=["$projectDir/src/main/bin_gen","$ext.binDir"]
 }
 applicationDistribution.from(bin_gen)

--- a/dex-translator/build.gradle
+++ b/dex-translator/build.gradle
@@ -1,11 +1,11 @@
 description = 'Dex Translator'
 
 dependencies {
-  compile project(':dex-reader')
-  compile project(':dex-ir')
-  compile project(':d2j-base-cmd')
-  compile 'org.ow2.asm:asm-debug-all:5.0.3'
-  testCompile project(':d2j-smali')
-  testCompile project(':d2j-jasmin')
+  api project(':dex-reader')
+  api project(':dex-ir')
+  api project(':d2j-base-cmd')
+  api 'org.ow2.asm:asm-debug-all:5.0.3'
+  testImplementation project(':d2j-smali')
+  testImplementation project(':d2j-jasmin')
 }
 

--- a/dex-writer/build.gradle
+++ b/dex-writer/build.gradle
@@ -1,7 +1,7 @@
 description = 'Dex Writer'
 
 dependencies {
-    compile project(':dex-reader-api')
-    testCompile group: 'junit', name: 'junit', version:'4.10'
-    testCompile project(':dex-reader')
+    api project(':dex-reader-api')
+    testImplementation group: 'junit', name: 'junit', version:'4.10'
+    testImplementation project(':dex-reader')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request is intended 
  1) to migrate from deprecated notation (compile and testCompile) to recommended notation
  2) to migrate deprecated plug-ins
  3) to update grade from 6.9.1 to 7.4.2 (to support recent OpenJDK)

Background is that
 For 1), please see https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal and gradle 7 already removed the support.
 For 2), please note that maven and java plug-ins are also deprecated.
 For 3), gradle 6.9.1 doesn't support recent OpenJDK. See https://docs.gradle.org/current/userguide/compatibility.html

Confirmed environment:
Gradle 7.4.2
Build time:   2022-03-31 15:25:29 UTC
Revision:     540473b8118064efcc264694cbcaa4b677f61041

Kotlin:       1.5.31
Groovy:       3.0.9
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          18.0.1.1 (Homebrew 18.0.1.1+0)
OS:           Mac OS X 12.4 aarch64

On this environment with pull request, dex2jar is successfully built.